### PR TITLE
fix Python 3 issue

### DIFF
--- a/ros2_repos_generator.py
+++ b/ros2_repos_generator.py
@@ -35,7 +35,7 @@ def _create_gist(repos_content, anonomous=True):
     if not response.ok:
         raise ConnectionError('failed to create gist')
 
-    gist_details = json.loads(response.content)
+    gist_details = json.loads(response.content.decode())
     return gist_details['files'][gist_file_name]['raw_url']
 
 
@@ -93,7 +93,7 @@ def _fetch_pr_info(pr_url):
     request_url = api_url + '/repos/{org}/{repo}/pulls/{pr_id}'.format(
             org=org, repo=repo, pr_id=pr_id)
     pr_info = requests.get(request_url)
-    jPr = json.loads(pr_info.content)
+    jPr = json.loads(pr_info.content.decode())
 
     repos_index = org + '/' + repo
     url = jPr['head']['repo']['html_url'] + '.git'


### PR DESCRIPTION
Otherwise I get:

```
$ python3 ros2_repos_generator.py https://github.com/ros2/examples/pull/197
analyzing pull request url
found github organization:  ros2
found github repo:  examples
found pull request number: 197
Traceback (most recent call last):
  File "ros2_repos_generator.py", line 110, in <module>
    pkg, url, branch = _fetch_pr_info(args.pr_url)
  File "ros2_repos_generator.py", line 96, in _fetch_pr_info
    jPr = json.loads(pr_info.content)
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```

or

```
$ python3 ros2_repos_generator.py https://github.com/ros2/rmw_fastrtps/pull/180
analyzing pull request url
found github organization:  ros2
found github repo:  rmw_fastrtps
found pull request number: 180
found pkg to replace   ros2/rmw_fastrtps:
Traceback (most recent call last):
  File "ros2_repos_generator.py", line 113, in <module>
    gist_url = _create_gist(modified_repos)
  File "ros2_repos_generator.py", line 38, in _create_gist
    gist_details = json.loads(response.content)
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```