### PR TITLE
Use raise_for_status() to get reason request was unsuccessful

### DIFF
--- a/ros2_repos_generator.py
+++ b/ros2_repos_generator.py
@@ -32,8 +32,7 @@ def _create_gist(repos_content, anonomous=True):
             api_url + '/gists',
             verify=True,
             data=jGist)
-    if not response.ok:
-        raise ConnectionError('failed to create gist')
+    response.raise_for_status()
 
     gist_details = json.loads(response.content.decode())
     return gist_details['files'][gist_file_name]['raw_url']


### PR DESCRIPTION
This will not raise if it was successful.

Gives info like:
```
Traceback (most recent call last):
  File "ros2_repos_generator.py", line 135, in <module>
    gist_url = _create_gist(modified_repos, token_param, auth)
  File "ros2_repos_generator.py", line 49, in _create_gist
    response.raise_for_status()
  File "/usr/local/lib/python3.6/site-packages/requests/models.py", line 935, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: https://api.github.com/gists
```